### PR TITLE
[typeshare] Support external tags for enums

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ dist/
 uploads.txt
 dist-manifest.json
 .intentionally-empty-file.o
+.DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,7 +697,7 @@ dependencies = [
 
 [[package]]
 name = "typeshare-cli"
-version = "1.12.0"
+version = "1.12.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "typeshare-core"
-version = "1.12.0"
+version = "1.12.1"
 dependencies = [
  "anyhow",
  "cool_asserts",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typeshare-cli"
-version = "1.12.0"
+version = "1.12.1"
 edition = "2021"
 description = "Command Line Tool for generating language files with typeshare"
 license = "MIT OR Apache-2.0"
@@ -26,7 +26,7 @@ once_cell = "1"
 rayon = "1.10"
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"
-typeshare-core = { path = "../core", version = "=1.12.0" }
+typeshare-core = { path = "../core", version = "=1.12.1" }
 log.workspace = true
 flexi_logger.workspace = true
 anyhow = "1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typeshare-core"
-version = "1.12.0"
+version = "1.12.1"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 description = "The code generator used by Typeshare's command line tool"

--- a/core/src/language/typescript.rs
+++ b/core/src/language/typescript.rs
@@ -216,32 +216,63 @@ impl TypeScript {
                 writeln!(w)?;
                 self.write_comments(w, 1, &v.shared().comments)?;
                 match v {
-                    RustEnumVariant::Unit(shared) => write!(
-                        w,
-                        "\t| {{ {}: {:?}, {}?: undefined }}",
-                        tag_key, shared.id.renamed, content_key
-                    ),
+                    RustEnumVariant::Unit(shared) => {
+                        if !tag_key.is_empty() {
+                            if !content_key.is_empty() {
+                                write!(
+                                    w,
+                                    "\t| {{ {}: {:?}, {}?: undefined }}",
+                                    tag_key, shared.id.renamed, content_key
+                                )
+                            } else {
+                                write!(w, "\t| {{ {}: {:?} }}", tag_key, shared.id.renamed)
+                            }
+                        } else {
+                            write!(w, "\t| {:?}", shared.id.renamed)
+                        }
+                    }
                     RustEnumVariant::Tuple { ty, shared } => {
                         let r#type = self
                             .format_type(ty, e.shared().generic_types.as_slice())
                             .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
-                        write!(
-                            w,
-                            "\t| {{ {}: {:?}, {}{}: {} }}",
-                            tag_key,
-                            shared.id.renamed,
-                            content_key,
-                            ty.is_optional().then_some("?").unwrap_or_default(),
-                            r#type
-                        )
+                        if !tag_key.is_empty() {
+                            if !content_key.is_empty() {
+                                write!(
+                                    w,
+                                    "\t| {{ {}: {:?}, {}{}: {} }}",
+                                    tag_key,
+                                    shared.id.renamed,
+                                    content_key,
+                                    ty.is_optional().then_some("?").unwrap_or_default(),
+                                    r#type
+                                )
+                            } else {
+                                panic!("Tuple variants must have a content key if they have a tag key: {:?}", shared.id.original)
+                            }
+                        } else {
+                            write!(
+                                w,
+                                "\t| {{ {:?}{}: {} }}",
+                                shared.id.renamed,
+                                ty.is_optional().then_some("?").unwrap_or_default(),
+                                r#type
+                            )
+                        }
                     }
                     RustEnumVariant::AnonymousStruct { fields, shared } => {
-                        writeln!(
-                            w,
-                            "\t| {{ {}: {:?}, {}: {{",
-                            tag_key, shared.id.renamed, content_key
-                        )?;
-
+                        if !tag_key.is_empty() {
+                            if !content_key.is_empty() {
+                                writeln!(
+                                    w,
+                                    "\t| {{ {}: {:?}, {}: {{",
+                                    tag_key, shared.id.renamed, content_key
+                                )?;
+                            } else {
+                                panic!("Struct variants must have a content key if they have a tag key: {:?}", shared.id.original)
+                            }
+                        } else {
+                            writeln!(w, "\t| {{ {:?}: {{", shared.id.renamed)?;
+                        }
                         fields.iter().try_for_each(|f| {
                             self.write_field(w, f, e.shared().generic_types.as_slice())
                         })?;

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -391,12 +391,8 @@ pub(crate) fn parse_enum(e: &ItemEnum, target_os: &[String]) -> Result<RustItem,
     } else {
         // At least one enum variant is either a tuple or an anonymous struct
 
-        let tag_key = maybe_tag_key.ok_or_else(|| ParseError::SerdeTagRequired {
-            enum_ident: original_enum_ident.clone(),
-        })?;
-        let content_key = maybe_content_key.ok_or_else(|| ParseError::SerdeContentRequired {
-            enum_ident: original_enum_ident.clone(),
-        })?;
+        let tag_key = maybe_tag_key.unwrap_or_default();
+        let content_key = maybe_content_key.unwrap_or_default();
 
         Ok(RustItem::Enum(RustEnum::Algebraic {
             tag_key,


### PR DESCRIPTION
## Description
* For complex enums the default serde serialization is externally tagged, to avoid having to re-write our rust logic to use internal tags via `#[serde(tag = "type", content = "content")]` we are going to add manual support for it in `typescript`
* Bumping version to `1.12.1`
* Adding a `--dry-run` flag to allow building locally

### Before
```
# Rust
enum MyEnum {
  blahblah {
    name: String
  }
  blahblah2 {
    age: u64
  }
}
```

```
# Typescript
export type MyEnum = 
  { "type": "blahblah", content: { "name": string }}
  | { "type": "blahblah2", content: { "age": number }}
```

### After
```
export type MyEnum =
 { "blahblah": { "name": string }}
| { "blahblah2": { "age": number }}
```

## Test Plan
* CI passes

## Revert Plan
* Revert
