### PR TITLE
[typeshare] Fix untagged support broken via rebase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,7 +731,7 @@ dependencies = [
 
 [[package]]
 name = "typeshare-cli"
-version = "1.13.3"
+version = "1.13.3-gitar"
 dependencies = [
  "anyhow",
  "clap",
@@ -748,7 +748,7 @@ dependencies = [
 
 [[package]]
 name = "typeshare-core"
-version = "1.13.3"
+version = "1.13.3-gitar"
 dependencies = [
  "anyhow",
  "convert_case",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typeshare-cli"
-version = "1.13.3"
+version = "1.13.3-gitar"
 edition = "2021"
 description = "Command Line Tool for generating language files with typeshare"
 license = "MIT OR Apache-2.0"
@@ -26,7 +26,7 @@ ignore = "0.4"
 once_cell = "1"
 serde = { version = "1", features = ["derive"] }
 toml = "0.9"
-typeshare-core = { path = "../core", version = "=1.13.3" }
+typeshare-core = { path = "../core", version = "=1.13.3-gitar" }
 log.workspace = true
 flexi_logger.workspace = true
 anyhow = "1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typeshare-core"
-version = "1.13.3"
+version = "1.13.3-gitar"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 description = "The code generator used by Typeshare's command line tool"

--- a/core/src/language/swift.rs
+++ b/core/src/language/swift.rs
@@ -588,6 +588,7 @@ impl Swift {
                 tag_key,
                 content_key,
                 shared,
+                ..
             } => {
                 let generics = &shared.generic_types;
                 for v in &shared.variants {

--- a/core/src/language/typescript.rs
+++ b/core/src/language/typescript.rs
@@ -285,6 +285,7 @@ impl TypeScript {
             RustEnum::Algebraic {
                 tag_key,
                 content_key,
+                untagged,
                 shared,
             } => shared.variants.iter().try_for_each(|v| {
                 writeln!(w)?;
@@ -323,9 +324,18 @@ impl TypeScript {
                             } else {
                                 panic!("Tuple variants must have a content key if they have a tag key: {:?}", shared.id.original)
                             }
-                        } else {
+                        } else if *untagged {
                             // Untagged: just output the inner type directly
                             write!(w, "\t| {}", r#type)
+                        } else {
+                            // Default externally-tagged: use variant name as key
+                            write!(
+                                w,
+                                "\t| {{ {:?}{}: {} }}",
+                                shared.id.renamed,
+                                if ty.is_optional() { "?" } else { Default::default() },
+                                r#type
+                            )
                         }
                     }
                     RustEnumVariant::AnonymousStruct { fields, shared } => {

--- a/core/src/language/typescript.rs
+++ b/core/src/language/typescript.rs
@@ -349,7 +349,11 @@ impl TypeScript {
                             } else {
                                 panic!("Struct variants must have a content key if they have a tag key: {:?}", shared.id.original)
                             }
+                        } else if *untagged {
+                            // Untagged: just output the struct fields directly
+                            writeln!(w, "\t| {{")?;
                         } else {
+                            // Default externally-tagged: use variant name as key
                             writeln!(w, "\t| {{ {:?}: {{", shared.id.renamed)?;
                         }
                         fields.iter().try_for_each(|f| {
@@ -357,7 +361,12 @@ impl TypeScript {
                         })?;
 
                         write!(w, "}}")?;
-                        write!(w, "}}")
+                        if !tag_key.is_empty() || !*untagged {
+                            // Close the outer wrapper for tagged enums
+                            write!(w, "}}")
+                        } else {
+                            Ok(())
+                        }
                     }
                 }
             }),

--- a/core/src/language/typescript.rs
+++ b/core/src/language/typescript.rs
@@ -324,13 +324,8 @@ impl TypeScript {
                                 panic!("Tuple variants must have a content key if they have a tag key: {:?}", shared.id.original)
                             }
                         } else {
-                            write!(
-                                w,
-                                "\t| {{ {:?}{}: {} }}",
-                                shared.id.renamed,
-                                if ty.is_optional() { "?" } else { Default::default() },
-                                r#type
-                            )
+                            // Untagged: just output the inner type directly
+                            write!(w, "\t| {}", r#type)
                         }
                     }
                     RustEnumVariant::AnonymousStruct { fields, shared } => {

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -323,6 +323,7 @@ pub(crate) fn parse_enum(
     // Grab the `#[serde(tag = "...", content = "...")]` values if they exist
     let maybe_tag_key = get_tag_key(&e.attrs);
     let maybe_content_key = get_content_key(&e.attrs);
+    let is_untagged = serde_attr(&e.attrs, "untagged");
 
     // Parse all of the enum's variants
     let variants = e
@@ -384,6 +385,7 @@ pub(crate) fn parse_enum(
         Ok(RustItem::Enum(RustEnum::Algebraic {
             tag_key,
             content_key,
+            untagged: is_untagged,
             shared,
         }))
     }

--- a/core/src/rust_types.rs
+++ b/core/src/rust_types.rs
@@ -678,6 +678,8 @@ pub enum RustEnum {
         tag_key: String,
         /// The parsed value of the `#[serde(content = "...")]` attribute
         content_key: String,
+        /// Whether this enum has `#[serde(untagged)]`
+        untagged: bool,
         /// Shared context for this enum.
         shared: RustEnumShared,
     },

--- a/core/src/topsort.rs
+++ b/core/src/topsort.rs
@@ -69,6 +69,7 @@ fn get_enum_dependencies(
             tag_key: _,
             content_key: _,
             shared,
+            ..
         } => {
             if seen.insert(shared.id.original.to_string()) {
                 res.push(shared.id.original.to_string());
@@ -203,6 +204,7 @@ pub(crate) fn topsort(things: &mut [RustItem]) {
                     tag_key: _,
                     content_key: _,
                     shared,
+                    ..
                 } => shared.id.original.clone(),
                 RustEnum::Unit(shared) => shared.id.original.clone(),
             },


### PR DESCRIPTION
## Description
* Support untagged that we lost via rebase

## Test Plan
* Verified it locally against enums that are untagged

## Revert Plan
* Revert

---

## Summary by Gitar

- **Fixed TypeScript codegen:**
  - Untagged tuple variants in `AlgebraicEnum` now output direct types instead of wrapped objects in `core/src/language/typescript.rs:324-329`
- **Version update:**
  - Bumped to `1.13.3-gitar` across `cli/Cargo.toml`, `core/Cargo.toml`, and `Cargo.lock`

---